### PR TITLE
added authentication support

### DIFF
--- a/check_jenkins.pl
+++ b/check_jenkins.pl
@@ -11,6 +11,7 @@
 #
 use strict;
 use LWP::UserAgent;
+use HTTP::Request::Common;
 use JSON;
 use Getopt::Long
   qw(GetOptions HelpMessage VersionMessage :config no_ignore_case bundling);
@@ -49,6 +50,8 @@ GetOptions(
     'debug|d'     => \$debug,
     'timeout|t=i' => \$timeout,
     'proxy=s',
+    'user|u=s',
+    'password|p=s',
     'noproxy',
     'noperfdata',
     'warning|w=i'  => \$jobs_warn,
@@ -78,6 +81,9 @@ else {
 }
 my $url = $ciMasterUrl . API_SUFFIX . '?tree=jobs[color,name]';
 my $req = HTTP::Request->new( GET => $url );
+if ( defined( $args{user} and defined ($args{password}) ) ) {
+    $req->authorization_basic( $args{user}, $args{password} );
+}
 trace("GET $url ...\n");
 my $res = $ua->request($req);
 if ( !$res->is_success ) {
@@ -191,6 +197,8 @@ check_jenkins.pl [options] <jenkins-url>
          --proxy=<url>         the http proxy url (default from
                                HTTP_PROXY env)
          --noproxy             do not use HTTP_PROXY env
+      -u --user                username for authentication
+      -p --password            password or api-key for authentication
          --noperfdata          do not output perdata
       -w --warning=<count>     the maximum total jobs count for WARNING threshold
       -c --critical=<count>    the maximum total jobs count for CRITICAL threshold
@@ -230,6 +238,14 @@ check_jenkins.pl [options] <jenkins-url>
 =item B<--noproxy>
 
     Do not use HTTP_PROXY env
+
+=item B<-u> B<--user=>user
+
+    Username for authentication
+
+=item B<-p> B<--password=>password
+
+    Password or API-Key for authentication
 
 =item B<--noperfdata>
 

--- a/check_jenkins_job_time.pl
+++ b/check_jenkins_job_time.pl
@@ -12,6 +12,7 @@
 # specified by its url.
 use strict;
 use LWP::UserAgent;
+use HTTP::Request::Common;
 use JSON;
 use Getopt::Long
   qw(GetOptions HelpMessage VersionMessage :config no_ignore_case bundling);
@@ -51,6 +52,8 @@ GetOptions(
     'debug|d'     => \$debug,
     'timeout|t=i' => \$timeout,
     'proxy=s',
+    'user|u=s',
+    'password|p=s',
     'noproxy',
     'noperfdata',
     'warning|w=i'    => \$warn,
@@ -82,6 +85,9 @@ my $url =
   . API_SUFFIX
   . '?tree=jobs[name,url,buildable,lastBuild[number,building,timestamp,estimatedDuration]]';
 my $req = HTTP::Request->new( GET => $url );
+if ( defined( $args{user} ) ) {
+    $req->authorization_basic( $args{user}, $args{password} );
+}
 trace( "Get ", $url, " ...\n" );
 my $res = $ua->request($req);
 if ( !$res->is_success ) {
@@ -263,6 +269,8 @@ check_jenkins_job_time.pl [options] <jenkins-url>
                                HTTP_PROXY env)
          --noproxy             do not use HTTP_PROXY env
          --noperfdata          do not output perdata
+      -u --user                username for authentication
+      -p --password            password or api-key for authentication
       -w --warning=<percent>   the percentage of usual duration for the WARNING threshold
       -c --critical=<percent>  the percentage of usual duration for the CRITICAL threshold
          --absoluteWarn=<minutes> the duration in minutes for the WARNING threshold
@@ -301,6 +309,14 @@ check_jenkins_job_time.pl [options] <jenkins-url>
 =item B<--noproxy>
 
     Do not use HTTP_PROXY env
+
+=item B<-u> B<--user=>user
+
+    Username for authentication
+
+=item B<-p> B<--password=>password
+
+    Password or API-Key for authentication
 
 =item B<--noperfdata>
 

--- a/check_jenkins_slaves.pl
+++ b/check_jenkins_slaves.pl
@@ -14,6 +14,7 @@
 #
 use strict;
 use LWP::UserAgent;
+use HTTP::Request::Common;
 use JSON;
 use Getopt::Long
   qw(GetOptions HelpMessage VersionMessage :config no_ignore_case bundling);
@@ -73,6 +74,8 @@ GetOptions(
     'timeout|t=i' => \$timeout,
     'proxy=s',
     'noproxy',
+    'user|u=s',
+    'password|p=s',
     'noperfdata',
     'statefull|s'    => \$compare,
     'warning|w=i'    => \$warn,
@@ -109,6 +112,9 @@ my $url =
   . API_SUFFIX
   . '?tree=computer[displayName,executors[idle],idle,offline,offlineCause[description],temporarilyOffline]';
 my $req = HTTP::Request->new(GET => $url);
+if ( defined( $args{user} ) ) {
+    $req->authorization_basic( $args{user}, $args{password} );
+}
 trace("Get ", $url, " ...\n");
 my $res = $ua->request($req);
 if (!$res->is_success) {
@@ -415,6 +421,8 @@ check_jenkins_slaves.pl [options] <jenkins-url>
          --proxy=<url>             the http proxy url (default from
                                    HTTP_PROXY env)
          --noproxy                 do not use HTTP_PROXY env
+      -u --user                    username for authentication
+      -p --password                password or api-key for authentication         
          --noperfdata              do not output perdata
       -s --statefull               turns on statefull (check difference with old states)
       -w --warning=<percent>       the percentage of offline slaves for the WARNING threshold
@@ -455,6 +463,14 @@ check_jenkins_slaves.pl [options] <jenkins-url>
 =item B<--noproxy>
 
     Do not use HTTP_PROXY env
+
+=item B<-u> B<--user=>user
+
+    Username for authentication
+
+=item B<-p> B<--password=>password
+
+    Password or API-Key for authentication
 
 =item B<--noperfdata>
 

--- a/check_jenkins_version.pl
+++ b/check_jenkins_version.pl
@@ -10,6 +10,7 @@
 #
 use strict;
 use LWP::UserAgent;
+use HTTP::Request::Common;
 use JSON;
 use Getopt::Long
   qw(GetOptions HelpMessage VersionMessage :config no_ignore_case bundling);
@@ -45,6 +46,8 @@ GetOptions(
     'timeout|t=i' => \$timeout,
     'proxy=s',
     'noproxy',
+    'user|u=s',
+    'password|p=s',
     'warning|w=s'  => \$warn_vers,
     'critical|c=s' => \$crit_vers
   )
@@ -68,6 +71,9 @@ else {
     }
 }
 my $req = HTTP::Request->new( HEAD => $ciMasterUrl . '/' );
+if ( defined( $args{user} ) ) {
+    $req->authorization_basic( $args{user}, $args{password} );
+}
 trace("HEAD $ciMasterUrl/ ...\n");
 my $res = $ua->request($req);
 if ( !$res->is_success ) {
@@ -105,6 +111,9 @@ if ( $jenkins_version >= '1.466' ) {
       . API_SUFFIX
       . '?tree=plugins[active,enabled,hasUpdate,longName,version]';
     $req = HTTP::Request->new( GET => $url );
+    if ( defined( $args{user} ) ) {
+        $req->authorization_basic( $args{user}, $args{password} );
+    }
     trace("GET $url \n");
     my $res = $ua->request($req);
     if ( !$res->is_success ) {
@@ -167,6 +176,8 @@ check_jenkins_version.pl [options] <jenkins-url>
          --proxy=<url>         the http proxy url (default from
                                HTTP_PROXY env)
          --noproxy             do not use HTTP_PROXY env
+      -u --user                username for authentication
+      -p --password            password or api-key for authentication
       -w --warning=<version>   the minimum version for WARNING threshold
       -c --critical=<version>  the minimum version for CRITICAL threshold
        
@@ -201,6 +212,14 @@ check_jenkins_version.pl [options] <jenkins-url>
 =item B<--noproxy>
 
     Do not use HTTP_PROXY env
+
+=item B<-u> B<--user=>user
+
+    Username for authentication
+
+=item B<-p> B<--password=>password
+
+    Password or API-Key for authentication
 
 =item B<-w> B<--warning=>version
 


### PR DESCRIPTION
This adds support for protected Jenkins instances where users must authenticate.
It adds two optional parameters (username and password/apikey) to all four scripts.

Authentication is done using basic auth